### PR TITLE
Include path /artists/#{@artist_1.id}

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -2,4 +2,8 @@ class ArtistsController < ApplicationController
   def index
     @artists = Artist.all
   end
+
+  def show
+    @artist = Artist.find(params[:id])
+  end
 end

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -1,0 +1,5 @@
+<h1>Artist Info</h1>
+<p>Artist: <%= @artist.name %></p>
+<p>Year born: <%= @artist.year_born %></p>
+<p>Country: <%= @artist.country %></p>
+<p>Alive?: <%= @artist.alive %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   # root "articles#index"
 
   get "/artists", to: "artists#index"
+  get "/artists/:id", to: "artists#show"
 end

--- a/spec/features/artists/index_spec.rb
+++ b/spec/features/artists/index_spec.rb
@@ -10,19 +10,33 @@ RSpec.describe 'artists index page', type: :feature do
   
   describe 'as a user' do
     describe 'when I visit /artists' do
-      it 'shows name of each artist record in the system' do
+      it 'shows the name of each artist record in the system' do
         # For each parent table
         # As a visitor
         # When I visit '/parents'
         # Then I see the name of each parent record in the system
         
         visit "/artists"
-        save_and_open_page
         expect(page).to have_content("All Artists")
         expect(page).to have_content(@artist_1.name)
         expect(page).to have_content(@artist_2.name)
         expect(page).to have_content(@artist_3.name)
         expect(page).to have_content(@artist_4.name)
+      end
+    end
+
+    describe 'when I visit /artists/:id' do
+      it 'shows the name of artist with that id including the attributes' do
+        # As a visitor
+        # When I visit '/parents/:id'
+        # Then I see the parent with that id including the parent's attributes
+        # (data from each column that is on the parent table)
+        visit "/artists/#{@artist_1.id}"
+        expect(page).to have_content(@artist_1.name)
+        expect(page).to have_content(@artist_1.year_born)
+        expect(page).to have_content(@artist_1.country)
+        expect(page).to have_content(@artist_1.alive)
+        expect(page).to_not have_content(@artist_2.name)
       end
     end
   end


### PR DESCRIPTION
User Story 2, Parent Show 

As a visitor
When I visit '/parents/:id'
Then I see the parent with that id including the parent's attributes
(data from each column that is on the parent table)