### PR TITLE
Add user story 18

### DIFF
--- a/app/views/paintings/index.html.erb
+++ b/app/views/paintings/index.html.erb
@@ -6,12 +6,14 @@
   <th>Painting Name</th>
   <th>Year Painted</th>
   <th>Oil Painting?</th>
+  <th>Update Painting</th>
 </tr>
 <% @paintings.each do |painting| %>
   <tr>
     <td><%= painting.name %></td>
     <td><%= painting.year_painted %></td>
     <td><%= painting.oil_painting %></td>
+    <td><%= link_to "Update #{painting.name}", "/paintings/#{painting.id}/edit", method: :get %></td>
   </tr>
 <% end %>
 

--- a/app/views/paintings/show.html.erb
+++ b/app/views/paintings/show.html.erb
@@ -3,4 +3,4 @@
 <p>Painting name: <%= @painting.name %></p>
 <p>Year painted: <%= @painting.year_painted %></p>
 <p>Oil painting?: <%= @painting.oil_painting %></p>
-<p><%= button_to "Update #{@painting.name}", "/paintings/#{@painting.id}/edit", method: :get %></p>
+<p><%= link_to "Update #{@painting.name}", "/paintings/#{@painting.id}/edit", method: :get %></p>

--- a/spec/features/paintings/edit_spec.rb
+++ b/spec/features/paintings/edit_spec.rb
@@ -3,20 +3,35 @@ require 'rails_helper'
 RSpec.describe 'editing painting', type: :feature do
   before :each do
     @artist_1 = Artist.create!(name: "Leonardo da Vinci", year_born: 1452, country: 'Italy', alive: false)
-    @painting_1 = @artist_1.paintings.create!(name: "Mona", year_painted: 1516, oil_painting: false)
+    @painting_1 = @artist_1.paintings.create!(name: "Mona", year_painted: 1516, oil_painting: true)
     @painting_2 = @artist_1.paintings.create!(name: "The Last Supper", year_painted: 1498, oil_painting: false)
+    @painting_3 = @artist_1.paintings.create!(name: "Vitruvian Man", year_painted: 1490, oil_painting: false)
+    @painting_4 = @artist_1.paintings.create!(name: "Lady with an Ermine", year_painted: 1491, oil_painting: true)
   end
 
   describe 'as a user' do
     describe 'the Painting edit' do
-      it 'allows you to click the link' do
+      it 'allows you to click the edit link from paintings index' do
+        # When I visit the parent index page
+        # Next to every parent, I see a link to edit that parent's info
+        # When I click the link
+        # I should be taken to that parent's edit page where I can update its information just like in User Story 12
+
+        visit "/paintings"
+        save_and_open_page
+        click_link("Update Mona")
+        expect(current_path).to eq("/paintings/#{@painting_1.id}/edit")
+        expect(current_path).to_not eq("/paintings")
+      end
+
+      it 'allows you to click the edit link from show page' do
         # When I visit a Child Show page
         # Then I see a link to update that Child "Update Child"
         # When I click the link
         # I am taken to '/child_table_name/:id/edit' where I see a form to edit the child's attributes:
 
         visit "/paintings/#{@painting_1.id}"
-        click_button("Update #{@painting_1.name}")
+        click_link("Update #{@painting_1.name}")
         
         expect(current_path).to eq("/paintings/#{@painting_1.id}/edit")
       end
@@ -28,7 +43,7 @@ RSpec.describe 'editing painting', type: :feature do
         # and I am redirected to the Child Show page where I see the Child's updated information
         visit "/paintings/#{@painting_1.id}"
         expect(page).to have_content("Mona")
-        click_button("Update Mona")
+        click_link("Update Mona")
         
         fill_in("Name", with: "Mona Lisa" )
         fill_in("Year painted", with: 1491)


### PR DESCRIPTION
As a visitor
When I visit the `child_table_name` index page or a parent `child_table_name` index page
Next to every child, I see a link to edit that child's info
When I click the link
I should be taken to that `child_table_name` edit page where I can update its information just like in User Story 14