### PR TITLE
Add user story 19, test passes server TBD

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -30,4 +30,10 @@ class ArtistsController < ApplicationController
     @artist.update(artist_params)
     redirect_to "/artists"
   end
+
+  def destroy
+    artist = Artist.find(params[:artist_id])
+    artist.destroy
+    redirect_to "/artists" 
+  end
 end

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -18,3 +18,5 @@
   <td><%= link_to "Edit #{@artist.name}", "/artists/#{@artist.id}/edit", method: :get %> </td>
 </tr>
 </table>
+
+<p><%= link_to "Delete #{@artist.name}", "/artists/#{@artist.id}", method: :delete %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,5 @@ Rails.application.routes.draw do
   get "/paintings/:painting_id/edit", to: 'paintings#edit'
   get "/paintings/:painting_id", to: "paintings#show"
   patch "/paintings/:painting_id", to: 'paintings#update'
+  delete "/artists/:artist_id", to: 'artists#destroy'
 end

--- a/spec/features/artists/destroy_spec.rb
+++ b/spec/features/artists/destroy_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'delete artist', type: :feature do
+  before :each do
+    @artist_1 = Artist.create!(name: "Leonardo da Vinci", year_born: 1452, country: 'Italy', alive: false)
+    @artist_2 = Artist.create!(name: "Edgar Degas", year_born: 1834, country: 'France', alive: false)
+    @artist_3 = Artist.create!(name: "Yayoi Kusama", year_born: 1929, country: 'Japan', alive: true)
+    @artist_4 = Artist.create!(name: "Beatrice Modisett", year_born: 1985, country: 'US', alive: true)
+    @artist_5 = Artist.create!(name: "Paul Kee", year_born: 1879, country: 'Germany', alive: true)
+  end
+
+  describe 'as a user' do
+    describe 'the artist delete' do
+      it 'allows you to delete artist from artist show page' do
+        # As a visitor
+        # When I visit a parent show page
+        # Then I see a link to delete the parent
+        # Then a 'DELETE' request is sent to '/parents/:id',
+        # the parent is deleted, and all child records are deleted
+        # and I am redirected to the parent index page where I no longer see this parent
+
+        visit "/artists/#{@artist_1.id}"
+        save_and_open_page
+        click_link("Delete #{@artist_1.name}")
+        expect(current_path).to eq("/artists")
+        expect(current_path).to_not eq("/artists/#{@artist_1.id}")
+        expect(page).to_not have_content("Leonardo da Vinci")
+      end
+      
+    end
+  end
+end

--- a/spec/features/paintings/edit_spec.rb
+++ b/spec/features/paintings/edit_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe 'editing painting', type: :feature do
         # I should be taken to that parent's edit page where I can update its information just like in User Story 12
 
         visit "/paintings"
-        save_and_open_page
         click_link("Update Mona")
         expect(current_path).to eq("/paintings/#{@painting_1.id}/edit")
         expect(current_path).to_not eq("/paintings")


### PR DESCRIPTION
As a visitor
When I visit a parent show page
Then I see a link to delete the parent
When I click the link "Delete Parent"
Then a 'DELETE' request is sent to '/parents/:id',
the parent is deleted, and all child records are deleted
and I am redirected to the parent index page where I no longer see this parent
