### PR TITLE
Feature extension 1

### DIFF
--- a/app/controllers/artist_paintings_controller.rb
+++ b/app/controllers/artist_paintings_controller.rb
@@ -3,10 +3,10 @@ class ArtistPaintingsController < ApplicationController
     @artist = Artist.find(params[:artist_id])
     @paintings = @artist.paintings
     if (params[:order] == "name")
-      @paintings = @artist.sort
+      @paintings = @artist.painting_sort
     elsif params[:search] != nil
       year = params[:search].to_i
-      @paintings = @artist.search(year)
+      @paintings = @artist.painting_search(year)
     end
   end
 

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,11 +1,9 @@
 class ArtistsController < ApplicationController
   def index
-    @artists = Artist.all
-    if params[:order] == "created_at"
-      require 'pry'; binding.pry
-      @artists.order_by_created
-      elsif params[:order] == "num_paints"
-        @artists.order_by_paintings
+    @artists = Artist.order_by_created
+    # require 'pry'; binding.pry
+    if params[:order] == "num_paint"
+      @artists = Artist.order_by_paintings
     end
   end
 

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,7 +1,12 @@
 class ArtistsController < ApplicationController
   def index
     @artists = Artist.all
-    @artists = @artists.order(created_at: :desc)
+    if params[:order] == "created_at"
+      require 'pry'; binding.pry
+      @artists.order_by_created
+      elsif params[:order] == "num_paints"
+        @artists.order_by_paintings
+    end
   end
 
   def show

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -7,23 +7,24 @@ class Artist < ApplicationRecord
   validates :alive, inclusion: [true, false]
   
   def number_of_paintings
-    self.paintings.count
+    paintings.count
   end
 
-  def sort
-    self.paintings.order(name: :asc)
+  def painting_sort
+    paintings.order(name: :asc)
   end
 
-  def search(year)
+  def painting_search(year)
     # 
-    self.paintings.where("year_painted > ?", year)
+    paintings.where("year_painted > ?", year)
   end
 
-  def order_by_created
-    self.order(created_at: :desc)
+  def self.order_by_created
+    order(created_at: :desc)
   end
 
-  def order_by_paintings
-    self.order(num_paints: :desc)
+  def self.order_by_paintings
+    joins(:paintings).group(:id).order("COUNT(paintings.id) DESC")
+
   end
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -18,4 +18,12 @@ class Artist < ApplicationRecord
     # 
     self.paintings.where("year_painted > ?", year)
   end
+
+  def order_by_created
+    self.order(created_at: :desc)
+  end
+
+  def order_by_paintings
+    self.order(num_paints: :desc)
+  end
 end

--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -3,6 +3,7 @@
 <table id="table">
 <tr>
   <th>Artist Name</th>
+  <th>Number of Paintings</th>
   <th>Created at</th>
   <th>Edit Artist</th>
   <th>Delete Artists</th>
@@ -11,6 +12,7 @@
 <% @artists.each do |artist| %>
   <tr>
     <td><%= link_to "#{artist.name}", "/artists/#{artist.id}" %> </td>
+    <td><%= artist.number_of_paintings %> </td>
     <td><%= artist.created_at %> </td>
     <td><%= link_to "Edit #{artist.name}", "/artists/#{artist.id}/edit", method: :get %> </td>
     <td><%= link_to "Delete #{artist.name}", "/artists/#{artist.id}", data: { turbo_method: :delete } %></td>
@@ -18,3 +20,4 @@
 <% end %>
 </table>
 <%= link_to "New Artist", "/artists/new" %>
+<%= link_to "Sort by # of Paintings", :order => "num_paint" %>

--- a/spec/features/artists/index_spec.rb
+++ b/spec/features/artists/index_spec.rb
@@ -6,6 +6,15 @@ RSpec.describe 'artists index page', type: :feature do
     @artist_2 = Artist.create!(name: "Edgar Degas", year_born: 1834, country: 'France', alive: false)
     @artist_3 = Artist.create!(name: "Yayoi Kusama", year_born: 1929, country: 'Japan', alive: true)
     @artist_4 = Artist.create!(name: "Beatrice Modisett", year_born: 1985, country: 'US', alive: true)
+    @painting_1 = @artist_1.paintings.create!(name: "Mona Lisa", year_painted: 1516, oil_painting: true)
+    @painting_3 = @artist_1.paintings.create!(name: "Vitruvian Man", year_painted: 1490, oil_painting: false)
+    @painting_5= @artist_2.paintings.create!(name: "Blue Dancers", year_painted: 1897, oil_painting: false)
+    @painting_13 = @artist_3.paintings.create!(name: "Flowers", year_painted: 1991, oil_painting: false)
+    @painting_14 = @artist_3.paintings.create!(name: "Pumpkin", year_painted: 1992, oil_painting: false)
+    @painting_15 = @artist_3.paintings.create!(name: "Infinity-Nets", year_painted: 2017, oil_painting: false)
+    @painting_16 = @artist_4.paintings.create!(name: "Pewter Clouds Being to Lighten", year_painted: 2022, oil_painting: false)
+    @painting_17 = @artist_4.paintings.create!(name: "Every Ninth Wave II", year_painted: 2018, oil_painting: true)
+  
   end
   
   describe 'as a user' do
@@ -66,6 +75,23 @@ RSpec.describe 'artists index page', type: :feature do
         expect(page).to have_link("Leonardo da Vinci")
         click_link("Leonardo da Vinci")
         expect(current_path).to eq("/artists/#{@artist_1.id}")
+      end
+
+      it 'shows number of paintings' do
+        visit "/artists"
+        expect(page).to have_content("Number of Paintings")
+      end
+
+      it 'can sort artists by number of paintings' do
+        visit "/artists"
+        expect(@artist_4.name).to appear_before(@artist_3.name)
+        
+        click_link("Sort by # of Paintings")
+
+        expect(current_path).to eq("/artists")
+        expect(@artist_3.name).to appear_before(@artist_1.name)
+        expect(@artist_1.name).to appear_before(@artist_2.name)
+        expect(@artist_2.name).to_not appear_before(@artist_4.name)
       end
     end
   end

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe Artist, type: :model do
     end
 
     it 'gives you sorted paintings' do
-      expect(@artist_1.sort).to eq([@painting_1, @painting_2])
+      expect(@artist_1.painting_sort).to eq([@painting_1, @painting_2])
     end
 
     it 'gives you search painting' do
-      expect(@artist_1.search(1500)).to eq([@painting_1])
+      expect(@artist_1.painting_search(1500)).to eq([@painting_1])
     end
 
   end


### PR DESCRIPTION
As a visitor
When I visit the Parents Index Page
Then I see a link to sort parents by the number of `child_table_name` they have
When I click on the link
I'm taken back to the Parent Index Page where I see all of the parents in order of their count of `child_table_name` (highest to lowest) And, I see the number of children next to each parent name